### PR TITLE
Rotated Surface Codes (Union-Find tested)

### DIFF
--- a/qsurface/codes/__init__.py
+++ b/qsurface/codes/__init__.py
@@ -7,4 +7,5 @@ from . import rotated
 CODES = [
     "toric",
     "planar",
+    "rotated"
 ]

--- a/qsurface/codes/rotated/__init__.py
+++ b/qsurface/codes/rotated/__init__.py
@@ -1,0 +1,2 @@
+from . import sim
+from . import plot

--- a/qsurface/codes/rotated/plot.py
+++ b/qsurface/codes/rotated/plot.py
@@ -1,0 +1,39 @@
+from .sim import PerfectMeasurements as SimPM, FaultyMeasurements as SimFM
+from .._template.plot import PerfectMeasurements as TemplatePM, FaultyMeasurements as TemplateFM
+
+
+class PerfectMeasurements(SimPM, TemplatePM):
+    # Inherited docstring
+
+    class Figure(TemplatePM.Figure):
+        # Inherited docstring
+
+        def __init__(self, code, *args, **kwargs) -> None:
+            self.main_boundary = [-1, -1, code.size[0] + 1, code.size[1] + 1]
+            super().__init__(code, *args, **kwargs)
+
+
+class FaultyMeasurements(SimFM, TemplateFM):
+    """Plotting code class for faulty measurements.
+
+    Inherits from `.codes.planar.sim.FaultyMeasurements` and `.codes.planar.plot.PerfectMeasurements`. See documentation for these classes for more.
+
+    Dependent on the ``figure3d`` argument, either a 3D figure object is created that inherits from `~.plot.Template3D` and `.codes.planar.plot.PerfectMeasurements.Figure`, or the 2D `.codes.planar.plot.PerfectMeasurements.Figure` is used.
+
+    Parameters
+    ----------
+    args
+        Positional arguments are passed on to `.codes.planar.sim.FaultyMeasurements`.
+    figure3d
+        Enables plotting on a 3D lattice. Disable to plot layer-by-layer on a 2D lattice, which increases responsiveness.
+    kwargs
+        Keyword arguments are passed on to `.codes.planar.sim.FaultyMeasurements` and the figure object.
+    """
+
+    class Figure2D(PerfectMeasurements.Figure, TemplateFM.Figure2D):
+        # Inherited docstring
+        pass
+
+    class Figure3D(PerfectMeasurements.Figure, TemplateFM.Figure3D):
+        # Inherited docstring
+        pass

--- a/qsurface/codes/rotated/sim.py
+++ b/qsurface/codes/rotated/sim.py
@@ -1,0 +1,97 @@
+from qsurface.codes.elements import AncillaQubit
+from ..toric.sim import PerfectMeasurements as ToricPM, FaultyMeasurements as ToricFM
+
+
+class PerfectMeasurements(ToricPM):
+    # Inherited docstring
+
+    name = "rotated"
+
+    _syndrome_dict = { 0: "x", 1: "z" }
+
+    def init_surface(self, z: float = 0, **kwargs):
+        """Initializes the rotated surface code on layer ``z``.
+
+        Parameters
+        ----------
+        z : int or float, optional
+            Layer of qubits, ``z=0`` for perfect measurements.
+        """
+        self.ancilla_qubits[z], self.data_qubits[z], self.pseudo_qubits[z] = {}, {}, {}
+        parity = self.init_parity_check
+
+        # Add data qubits to surface
+        for y in range(self.size[1]):
+            for x in range(self.size[0]):
+                self.add_data_qubit((x, y), z=z, **kwargs)
+
+        # Add ancilla qubits to surface
+        if self.size[1] % 2 == 1:
+            for y in range(self.size[1] - 1):
+                for x in range(self.size[0]):
+                    parity(self.add_ancilla_qubit((0.5 - 1 * (y%2) + x, y + 0.5), z=z, state_type=self._syndrome_dict[x%2], **kwargs))
+        else:
+            commute = -1
+            for y in range(self.size[1] - 1):
+                for x in range(self.size[0] + commute):
+                    commute *= -1
+                    parity(self.add_ancilla_qubit((0.5 - 1 * (y%2) + x, y + 0.5), z=z, state_type=self._syndrome_dict[x%2], **kwargs))
+
+        outer_qubits = self.size[0] // 2
+
+        for x in range(outer_qubits): # for first and last row
+            parity(self.add_ancilla_qubit((0.5 + 2*x, -0.5), z=z, state_type=self._syndrome_dict[1], **kwargs))
+            parity(self.add_ancilla_qubit((self.size[0] - 1.5 - 2*x, self.size[1] - 0.5), z=z, state_type=self._syndrome_dict[1], **kwargs))
+
+        # Add pseudo qubits to surface (boundaries)
+        if self.size[1] % 2 == 1:
+            for y in range(self.size[1] - 1):
+                if y % 2 == 0:
+                    parity(self.add_pseudo_qubit((-0.5, y + 0.5), z=z, state_type=self._syndrome_dict[1], **kwargs))
+                else:
+                    parity(self.add_pseudo_qubit((self.size[0] - 0.5, y + 0.5), z=z, state_type=self._syndrome_dict[1], **kwargs))
+        else:
+            for y in range(self.size[1] - 1):
+                if y % 2 == 0:
+                    parity(self.add_pseudo_qubit((-0.5, y + 0.5), z=z, state_type=self._syndrome_dict[1], **kwargs))
+                    parity(self.add_pseudo_qubit((self.size[0] - 0.5, y + 0.5), z=z, state_type=self._syndrome_dict[1], **kwargs))
+
+        for x in range(self.size[0]+1):
+            if x % 2 == 0 or x >= (outer_qubits)*2:
+                parity(self.add_pseudo_qubit((x - 0.5, - 0.5), z=z, state_type=self._syndrome_dict[x % 2], **kwargs))
+                parity(self.add_pseudo_qubit((self.size[0] - 0.5 - x, self.size[1] - 0.5), z=z, state_type=self._syndrome_dict[x % 2], **kwargs))
+
+    def init_parity_check(self, ancilla_qubit: AncillaQubit, **kwargs):
+        """Initiates a parity check measurement.
+
+        For every ancilla qubit on ``(x,y)``, four neighboring data qubits are entangled for parity check measurements.
+
+        Parameters
+        ----------
+        ancilla_qubit : `~.codes.elements.AncillaQubit`
+            Ancilla qubit to initialize.
+        """
+        (x, y), z = ancilla_qubit.loc, ancilla_qubit.z
+        checks = {
+            (0.5, 0.5): ((x + 0.5), (y+0.5)),
+            (-0.5, 0.5): ((x - 0.5), (y+0.5)),
+            (0.5, -0.5): ((x + 0.5), (y - 0.5)),
+            (-0.5, -0.5): ((x - 0.5), (y - 0.5)),
+        }
+        for key, loc in checks.items():
+            if loc in self.data_qubits[z]:
+                self.entangle_pair(self.data_qubits[z][loc], ancilla_qubit, key)
+
+    def init_logical_operator(self, **kwargs):
+        """Initiates the logical operators [x,z] of the rotated code."""
+        operators = {
+            "x": [self.data_qubits[self.decode_layer][(0, i)].edges["x"] for i in range(self.size[0])],
+            "z": [self.data_qubits[self.decode_layer][(i, 0)].edges["z"] for i in range(self.size[1])],
+        }
+        self.logical_operators = operators
+
+
+class FaultyMeasurements(ToricFM, PerfectMeasurements):
+    # Inherited docstring
+
+    pass

--- a/qsurface/codes/rotated/sim.py
+++ b/qsurface/codes/rotated/sim.py
@@ -85,8 +85,8 @@ class PerfectMeasurements(ToricPM):
     def init_logical_operator(self, **kwargs):
         """Initiates the logical operators [x,z] of the rotated code."""
         operators = {
-            "x": [self.data_qubits[self.decode_layer][(0, i)].edges["x"] for i in range(self.size[0])],
-            "z": [self.data_qubits[self.decode_layer][(i, 0)].edges["z"] for i in range(self.size[1])],
+            "x": [self.data_qubits[self.decode_layer][(i, 0)].edges["x"] for i in range(self.size[0])],
+            "z": [self.data_qubits[self.decode_layer][(0, i)].edges["z"] for i in range(self.size[1])],
         }
         self.logical_operators = operators
 

--- a/qsurface/decoders/mwpm/plot.py
+++ b/qsurface/decoders/mwpm/plot.py
@@ -1,4 +1,4 @@
-from .sim import Toric as SimToric, Planar as SimPlanar, Planar as SimRotated
+from .sim import Toric as SimToric, Planar as SimPlanar
 from .._template import Plot
 
 
@@ -21,17 +21,6 @@ class Planar(Toric, SimPlanar):
     ----------
     args, kwargs
         Positional and keyword arguments are passed on to `~.decoders.mwpm.plot.Toric` and `.decoders.mwpm.sim.Planar`.
-    """
-
-    pass
-
-class Rotated(Planar, SimRotated):
-    """Plot MWPM decoder for the rotated planar code.
-
-    Parameters
-    ----------
-    args, kwargs
-        Positional and keyword arguments are passed on to `~.decoders.mwpm.plot.Toric`.
     """
 
     pass

--- a/qsurface/decoders/mwpm/plot.py
+++ b/qsurface/decoders/mwpm/plot.py
@@ -1,4 +1,4 @@
-from .sim import Toric as SimToric, Planar as SimPlanar
+from .sim import Toric as SimToric, Planar as SimPlanar, Planar as SimRotated
 from .._template import Plot
 
 
@@ -21,6 +21,17 @@ class Planar(Toric, SimPlanar):
     ----------
     args, kwargs
         Positional and keyword arguments are passed on to `~.decoders.mwpm.plot.Toric` and `.decoders.mwpm.sim.Planar`.
+    """
+
+    pass
+
+class Rotated(Planar, SimRotated):
+    """Plot MWPM decoder for the rotated planar code.
+
+    Parameters
+    ----------
+    args, kwargs
+        Positional and keyword arguments are passed on to `~.decoders.mwpm.plot.Toric`.
     """
 
     pass

--- a/qsurface/decoders/unionfind/plot.py
+++ b/qsurface/decoders/unionfind/plot.py
@@ -1,7 +1,7 @@
 from ...codes.elements import AncillaQubit, DataQubit, Edge
 from ...plot import Template2D, Template3D
 from .._template import Plot
-from .sim import Toric as SimToric, Planar as SimPlanar
+from .sim import Toric as SimToric, Planar as SimPlanar, Rotated as SimRotated
 from matplotlib.patches import Rectangle
 from matplotlib.lines import Line2D
 
@@ -362,3 +362,9 @@ class Planar(Toric, SimPlanar):
         def _plot_ancilla(self, ancilla, **kwargs):
             if type(ancilla) == AncillaQubit:
                 super()._plot_ancilla(ancilla, **kwargs)
+
+class Rotated(Planar, SimRotated):
+    def init_plot(self, **kwargs):
+        # Inherited docstring
+        size = [xy - 0.5 for xy in self.code.size]
+        self._init_axis([-0.5, -0.5] + size, title=self.decoder, aspect="equal")

--- a/qsurface/decoders/unionfind/sim.py
+++ b/qsurface/decoders/unionfind/sim.py
@@ -661,3 +661,6 @@ class Planar(Toric):
                         key, (new_ancilla, edge) = leaf
                         self._edge_peel(edge, variant="peel")
                         self.peel_leaf(cluster, new_ancilla)
+
+class Rotated(Planar):
+    pass

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-matplotlib>=3.3.2
+setuptools
+matplotlib~=3.5.1
+numpy~=1.9
 networkx>=2.0
 pandas>=1.1.0
 scipy>=1.4.0


### PR DESCRIPTION
I implemented Rotated Surface Codes as an extension of basic planar codes. I did this mainly for my Master Thesis so I'm sorry I didn't include appropriate tests and didn't cover all decoders, but I'm mainly focusing my thesis on Union-Find, so that was my scope.

# Changelog

# Rotated Code

* Implemented surface topology for even and odd distance rotated codes.
* Parity checks defined in a diagonal fashion due to the rotated grid.
* Logical operators defined as vertical and horizontal operators on both axes.

# Decoders

* **Union-Find:** didn't need to change it at all, I just had to include the _Rotated_ class as a direct extension of the _Planar_ class. It worked just fine (didn't try on _UFNS_).
* **MWPM:** tried to touch it but it didn't work, didn't really dig on that deeply. As a note on this, it seems to me it doesn't really work on planar codes so I didn't know if it was worth looking into it.

## Minor notes

* Requirements updated due to legacy features (mainly _matplotlib.blocking_input_ and _numpy.Inf_ issues).